### PR TITLE
Feat: Add refresh service action shortcut and display it on header

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,6 +16,7 @@ Language: Json
 DisableFormat: false
 IndentWidth: 4
 ---
+
 # Style for C++
 Language: Cpp
 
@@ -85,18 +86,7 @@ SpaceAfterTemplateKeyword: false
 AlwaysBreakTemplateDeclarations: true
 
 # macros for which the opening brace stays attached.
-ForEachMacros:
-  [
-    foreach,
-    Q_FOREACH,
-    BOOST_FOREACH,
-    forever,
-    Q_FOREVER,
-    QBENCHMARK,
-    QBENCHMARK_ONCE,
-    wl_resource_for_each,
-    wl_resource_for_each_safe,
-  ]
+ForEachMacros: [ foreach, Q_FOREACH, BOOST_FOREACH, forever, Q_FOREVER, QBENCHMARK, QBENCHMARK_ONCE , wl_resource_for_each, wl_resource_for_each_safe ]
 
 # keep lambda formatting multi-line if not empty
 AllowShortLambdasOnASingleLine: Empty

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -1074,6 +1074,17 @@ Kirigami.ApplicationWindow {
         }
     }
 
+    // Refresh current service with Ctrl+R or F5
+    Shortcut {
+        sequences: ["Ctrl+R", "F5"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            if (root.currentServiceId !== "" && root.webViewStack) {
+                root.webViewStack.refreshByServiceId(root.currentServiceId);
+            }
+        }
+    }
+
     // --- Numeric shortcuts: Ctrl+1..9 for services (within current workspace) ---
     // Helper to switch to Nth service (1-based) in filteredServices
     function switchToServiceByPosition(pos) {


### PR DESCRIPTION
Adds a refresh button to the header toolbar for reloading the current service.
Adds a keyboard shortcut (Ctrl+R / F5) to refresh the active service.