### PR TITLE
Fix: Fix favicon preview not displaying for domain-only URLs

### DIFF
--- a/src/qml/dialogs/ServiceDialog.qml
+++ b/src/qml/dialogs/ServiceDialog.qml
@@ -469,7 +469,19 @@ Kirigami.Dialog {
         target: typeof faviconCache !== "undefined" ? faviconCache : null
 
         function onFaviconSourceReady(serviceUrl, source, localPath) {
-            if (serviceUrlField.text && serviceUrl === serviceUrlField.text.trim()) {
+            // Normalize both URLs for comparison (prepend https:// if no protocol)
+            var normalizedServiceUrl = serviceUrl;
+            var normalizedFieldUrl = serviceUrlField.text.trim();
+
+            if (!normalizedServiceUrl.startsWith("http://") && !normalizedServiceUrl.startsWith("https://")) {
+                normalizedServiceUrl = "https://" + normalizedServiceUrl;
+            }
+
+            if (!normalizedFieldUrl.startsWith("http://") && !normalizedFieldUrl.startsWith("https://")) {
+                normalizedFieldUrl = "https://" + normalizedFieldUrl;
+            }
+
+            if (normalizedFieldUrl && normalizedServiceUrl === normalizedFieldUrl) {
                 if (source === 0) { // Google
                     root.googleFaviconUrl = localPath;
                     root.googleFaviconLoading = false;


### PR DESCRIPTION
## Problem
When adding a service with a domain-only URL (e.g., "example.com" instead of "https://example.com"), the favicon preview buttons were not showing the fetched icons. The favicons were being downloaded and cached, but they weren't displayed in the UI.

## Solution
Normalize both URLs before comparison by prepending "https://" if no protocol is specified. This ensures the URLs match regardless of whether the user entered the protocol or not.