### PR TITLE
Fix: Allow enabling/disabling services from any workspace

### DIFF
--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -1455,7 +1455,7 @@ Kirigami.ApplicationWindow {
     // Function to disable/enable a service
     function setServiceEnabled(serviceId, enabled) {
         var service = findServiceById(serviceId);
-        if (service && service.workspace === currentWorkspace) {
+        if (service) {
             var webView = webViewStack.getWebViewByServiceId(serviceId);
             if (webView) {
                 if (enabled) {
@@ -1468,7 +1468,7 @@ Kirigami.ApplicationWindow {
                     webView.stop();
                     webView.url = "about:blank";
                 }
-                // Update configManager to persist the state
+                // Update configManager to persist the disabled state
                 if (configManager && configManager.setServiceDisabled) {
                     configManager.setServiceDisabled(serviceId, !enabled);
                 }


### PR DESCRIPTION
Previously, the `setServiceEnabled()` function only worked for services in the current workspace due to a workspace check. This prevented users from enabling or disabling services that were in other workspaces.

Services can now be enabled/disabled regardless of which workspace they belong to.