### PR TITLE
feat(sidebar): add tiny/small/normal/big size preset

### DIFF
--- a/po/Unify.pot
+++ b/po/Unify.pot
@@ -309,6 +309,35 @@ msgstr ""
 msgid "${ws}"
 msgstr ""
 
+#: src/qml/drawers/WorkspaceDrawer.qml:116
+#, kde-format
+msgid "Sidebar Size"
+msgstr ""
+
+#: src/qml/drawers/WorkspaceDrawer.qml:120
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Tiny"
+msgstr ""
+
+#: src/qml/drawers/WorkspaceDrawer.qml:130
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Small"
+msgstr ""
+
+#: src/qml/drawers/WorkspaceDrawer.qml:140
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Normal"
+msgstr ""
+
+#: src/qml/drawers/WorkspaceDrawer.qml:150
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Big"
+msgstr ""
+
 #: src/trayiconmanager.cpp:57
 #, kde-format
 msgid "Show Unify"

--- a/po/es.po
+++ b/po/es.po
@@ -316,6 +316,35 @@ msgstr ""
 msgid "${ws}"
 msgstr "${ws}"
 
+#: src/qml/drawers/WorkspaceDrawer.qml:116
+#, kde-format
+msgid "Sidebar Size"
+msgstr "Tamaño de la barra lateral"
+
+#: src/qml/drawers/WorkspaceDrawer.qml:120
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Tiny"
+msgstr "Muy pequeña"
+
+#: src/qml/drawers/WorkspaceDrawer.qml:130
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Small"
+msgstr "Pequeña"
+
+#: src/qml/drawers/WorkspaceDrawer.qml:140
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Normal"
+msgstr "Normal"
+
+#: src/qml/drawers/WorkspaceDrawer.qml:150
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Big"
+msgstr "Grande"
+
 #: src/trayiconmanager.cpp:57
 #, kde-format
 msgid "Show Unify"

--- a/po/nl.po
+++ b/po/nl.po
@@ -315,6 +315,35 @@ msgstr ""
 msgid "${ws}"
 msgstr "${ws}"
 
+#: src/qml/drawers/WorkspaceDrawer.qml:116
+#, kde-format
+msgid "Sidebar Size"
+msgstr ""
+
+#: src/qml/drawers/WorkspaceDrawer.qml:120
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Tiny"
+msgstr ""
+
+#: src/qml/drawers/WorkspaceDrawer.qml:130
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Small"
+msgstr ""
+
+#: src/qml/drawers/WorkspaceDrawer.qml:140
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Normal"
+msgstr ""
+
+#: src/qml/drawers/WorkspaceDrawer.qml:150
+#, kde-format
+msgctxt "Sidebar size preset"
+msgid "Big"
+msgstr ""
+
 #: src/trayiconmanager.cpp:57
 #, kde-format
 msgid "Show Unify"

--- a/src/core/configmanager.cpp
+++ b/src/core/configmanager.cpp
@@ -344,6 +344,20 @@ void ConfigManager::setShowZoomInHeader(bool enabled)
     }
 }
 
+QString ConfigManager::sidebarSizePreset() const
+{
+    return m_sidebarSizePreset;
+}
+
+void ConfigManager::setSidebarSizePreset(const QString &preset)
+{
+    if (m_sidebarSizePreset != preset) {
+        m_sidebarSizePreset = preset;
+        Q_EMIT sidebarSizePresetChanged();
+        saveSettings();
+    }
+}
+
 void ConfigManager::addService(const QVariantMap &service)
 {
     QVariantMap newService = service;
@@ -625,6 +639,7 @@ void ConfigManager::saveSettings()
     m_settings.setValue(QStringLiteral("systemTrayEnabled"), m_systemTrayEnabled);
     m_settings.setValue(QStringLiteral("showZoomInHeader"), m_showZoomInHeader);
     m_settings.setValue(QStringLiteral("globalMute"), m_globalMute);
+    m_settings.setValue(QStringLiteral("sidebarSizePreset"), m_sidebarSizePreset);
     m_settings.endGroup();
 
     m_settings.sync();
@@ -692,6 +707,7 @@ void ConfigManager::loadSettings()
     m_systemTrayEnabled = m_settings.value(QStringLiteral("systemTrayEnabled"), true).toBool();
     m_showZoomInHeader = m_settings.value(QStringLiteral("showZoomInHeader"), true).toBool();
     m_globalMute = m_settings.value(QStringLiteral("globalMute"), false).toBool();
+    m_sidebarSizePreset = m_settings.value(QStringLiteral("sidebarSizePreset"), QStringLiteral("normal")).toString();
     m_settings.endGroup();
 
     // Only update workspaces list if it's empty (first run)

--- a/src/core/configmanager.h
+++ b/src/core/configmanager.h
@@ -25,6 +25,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool confirmDownloads READ confirmDownloads WRITE setConfirmDownloads NOTIFY confirmDownloadsChanged)
     Q_PROPERTY(bool systemTrayEnabled READ systemTrayEnabled WRITE setSystemTrayEnabled NOTIFY systemTrayEnabledChanged)
     Q_PROPERTY(bool showZoomInHeader READ showZoomInHeader WRITE setShowZoomInHeader NOTIFY showZoomInHeaderChanged)
+    Q_PROPERTY(QString sidebarSizePreset READ sidebarSizePreset WRITE setSidebarSizePreset NOTIFY sidebarSizePresetChanged)
 
 public:
     explicit ConfigManager(QObject *parent = nullptr);
@@ -93,6 +94,9 @@ public:
     bool showZoomInHeader() const;
     void setShowZoomInHeader(bool enabled);
 
+    QString sidebarSizePreset() const;
+    void setSidebarSizePreset(const QString &preset);
+
     Q_INVOKABLE void saveSettings();
     Q_INVOKABLE void loadSettings();
 
@@ -130,6 +134,7 @@ Q_SIGNALS:
     void confirmDownloadsChanged();
     void systemTrayEnabledChanged();
     void showZoomInHeaderChanged();
+    void sidebarSizePresetChanged();
 
 private:
     void updateWorkspacesList();
@@ -150,6 +155,7 @@ private:
     bool m_confirmDownloads = true;
     bool m_systemTrayEnabled = true;
     bool m_showZoomInHeader = true;
+    QString m_sidebarSizePreset = QStringLiteral("normal");
 };
 
 #endif // CONFIGMANAGER_H

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -19,8 +19,16 @@ Kirigami.ApplicationWindow {
     width: 1200
     height: 800
 
-    property int buttonSize: 64
-    property int iconSize: 64 - Kirigami.Units.smallSpacing * 4
+    // Sidebar size presets — mapping configManager.sidebarSizePreset to button pixel size.
+    // Tiny/Small/Big are derived from the previous fixed Normal value (64) at 40/60/120 %.
+    readonly property var sidebarSizePresets: ({
+        "tiny": 26,
+        "small": 38,
+        "normal": 64,
+        "big": 77
+    })
+    property int buttonSize: sidebarSizePresets[configManager ? configManager.sidebarSizePreset : "normal"] || 64
+    property int iconSize: Math.round(buttonSize * 0.75)
     property int sidebarWidth: buttonSize + Kirigami.Units.smallSpacing * 2
 
     // Current selected service name for the header

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -20,14 +20,13 @@ Kirigami.ApplicationWindow {
     height: 800
 
     // Sidebar size presets — mapping configManager.sidebarSizePreset to button pixel size.
-    // Tiny/Small/Big are derived from the previous fixed Normal value (64) at 40/60/120 %.
     readonly property var sidebarSizePresets: ({
-        "tiny": 26,
-        "small": 38,
-        "normal": 64,
-        "big": 77
+        "tiny": Kirigami.Units.gridUnit * 2,
+        "small": Kirigami.Units.gridUnit * 3,
+        "normal": Kirigami.Units.gridUnit * 4,
+        "big": Kirigami.Units.gridUnit * 5
     })
-    property int buttonSize: sidebarSizePresets[configManager ? configManager.sidebarSizePreset : "normal"] || 64
+    property int buttonSize: sidebarSizePresets[configManager ? configManager.sidebarSizePreset : "normal"] || sidebarSizePresets.normal
     property int iconSize: Math.round(buttonSize * 0.75)
     property int sidebarWidth: buttonSize + Kirigami.Units.smallSpacing * 2
 

--- a/src/qml/drawers/WorkspaceDrawer.qml
+++ b/src/qml/drawers/WorkspaceDrawer.qml
@@ -109,6 +109,56 @@ Kirigami.Action { separator: true }
             }
         `, drawer));
 
+        // Sidebar Size submenu (Tiny / Small / Normal / Big)
+        acts.push(Qt.createQmlObject(`
+            import org.kde.kirigami as Kirigami
+            Kirigami.Action {
+                text: i18n("Sidebar Size")
+                icon.name: "view-sort-symbolic"
+
+                Kirigami.Action {
+                    text: i18nc("Sidebar size preset", "Tiny")
+                    checkable: true
+                    checked: configManager && configManager.sidebarSizePreset === "tiny"
+                    onTriggered: {
+                        if (configManager) {
+                            configManager.sidebarSizePreset = "tiny"
+                        }
+                    }
+                }
+                Kirigami.Action {
+                    text: i18nc("Sidebar size preset", "Small")
+                    checkable: true
+                    checked: configManager && configManager.sidebarSizePreset === "small"
+                    onTriggered: {
+                        if (configManager) {
+                            configManager.sidebarSizePreset = "small"
+                        }
+                    }
+                }
+                Kirigami.Action {
+                    text: i18nc("Sidebar size preset", "Normal")
+                    checkable: true
+                    checked: configManager && configManager.sidebarSizePreset === "normal"
+                    onTriggered: {
+                        if (configManager) {
+                            configManager.sidebarSizePreset = "normal"
+                        }
+                    }
+                }
+                Kirigami.Action {
+                    text: i18nc("Sidebar size preset", "Big")
+                    checkable: true
+                    checked: configManager && configManager.sidebarSizePreset === "big"
+                    onTriggered: {
+                        if (configManager) {
+                            configManager.sidebarSizePreset = "big"
+                        }
+                    }
+                }
+            }
+        `, drawer));
+
         // Show Workspaces Bar toggle
         acts.push(Qt.createQmlObject(`
             import org.kde.kirigami as Kirigami


### PR DESCRIPTION
Hey @DenysMb, I love your app — I've been using it for a while. A few weeks ago I was about to build my own Rambox/Ferdi alternative without all the bloat, then I came across yours and it does pretty much everything I need. Respectfully, I've made some tweaks for my daily use; if you're open to contributions, I'd like to share them with you — they're all opt-in, and I've tried to stay as close to your code and conventions as I could. Sending them split so you can decline any individually:

- **This PR** — Cuts the sidebar size to something more discreet, by preset.
- **Second PR** — Lets the user hide the header — most of us aren't adding services every day, so we don't need to see it all the time.
- **Third PR** — Minimal addition: the user could just put the app in autostart manually, but having a one-click toggle is always nice.

The `main` branch on my fork has all three combined if you want to try them together.

Cheers, and thanks for your excellent app!

---

**Tech approach.** New `sidebarSizePreset` QString on `ConfigManager` (persisted in the existing `Display` group) drives `buttonSize`/`iconSize`/`sidebarWidth` in `Main.qml` from a four-entry lookup — Tiny=26, Small=38, Normal=64, Big=77 px — with `iconSize = round(buttonSize * 0.75)` so the icon-to-button ratio is preserved. Default `"normal"` keeps existing installs pixel-identical; the picker is exposed as a four-option submenu in the global drawer.