### PR TITLE
feat(header): add Ctrl+H toggle to hide the application header

### DIFF
--- a/po/Unify.pot
+++ b/po/Unify.pot
@@ -50,6 +50,12 @@ msgctxt "@title:window"
 msgid "Unify"
 msgstr ""
 
+#: src/qml/Main.qml:569
+#, kde-format
+msgctxt "@title:window"
+msgid "Unify - %1"
+msgstr ""
+
 #: src/qml/Main.qml:456 src/qml/dialogs/ServiceDialog.qml:28
 #, kde-format
 msgid "Add Service"
@@ -307,6 +313,11 @@ msgstr ""
 #: src/qml/drawers/WorkspaceDrawer.qml:22
 #, kde-format
 msgid "${ws}"
+msgstr ""
+
+#: src/qml/drawers/WorkspaceDrawer.qml:209
+#, kde-format
+msgid "Hide Header (Ctrl+H)"
 msgstr ""
 
 #: src/trayiconmanager.cpp:57

--- a/po/es.po
+++ b/po/es.po
@@ -51,6 +51,12 @@ msgctxt "@title:window"
 msgid "Unify"
 msgstr "Unify"
 
+#: src/qml/Main.qml:569
+#, kde-format
+msgctxt "@title:window"
+msgid "Unify - %1"
+msgstr "Unify - %1"
+
 #: src/qml/Main.qml:456 src/qml/dialogs/ServiceDialog.qml:28
 #, kde-format
 msgid "Add Service"
@@ -315,6 +321,11 @@ msgstr ""
 #, kde-format
 msgid "${ws}"
 msgstr "${ws}"
+
+#: src/qml/drawers/WorkspaceDrawer.qml:209
+#, kde-format
+msgid "Hide Header (Ctrl+H)"
+msgstr "Ocultar cabecera (Ctrl+H)"
 
 #: src/trayiconmanager.cpp:57
 #, kde-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -51,6 +51,12 @@ msgctxt "@title:window"
 msgid "Unify"
 msgstr "Unify"
 
+#: src/qml/Main.qml:569
+#, kde-format
+msgctxt "@title:window"
+msgid "Unify - %1"
+msgstr ""
+
 #: src/qml/Main.qml:456 src/qml/dialogs/ServiceDialog.qml:28
 #, kde-format
 msgid "Add Service"
@@ -314,6 +320,11 @@ msgstr ""
 #, kde-format
 msgid "${ws}"
 msgstr "${ws}"
+
+#: src/qml/drawers/WorkspaceDrawer.qml:209
+#, kde-format
+msgid "Hide Header (Ctrl+H)"
+msgstr ""
 
 #: src/trayiconmanager.cpp:57
 #, kde-format

--- a/src/core/configmanager.cpp
+++ b/src/core/configmanager.cpp
@@ -344,6 +344,20 @@ void ConfigManager::setShowZoomInHeader(bool enabled)
     }
 }
 
+bool ConfigManager::hideHeader() const
+{
+    return m_hideHeader;
+}
+
+void ConfigManager::setHideHeader(bool enabled)
+{
+    if (m_hideHeader != enabled) {
+        m_hideHeader = enabled;
+        Q_EMIT hideHeaderChanged();
+        saveSettings();
+    }
+}
+
 void ConfigManager::addService(const QVariantMap &service)
 {
     QVariantMap newService = service;
@@ -625,6 +639,7 @@ void ConfigManager::saveSettings()
     m_settings.setValue(QStringLiteral("systemTrayEnabled"), m_systemTrayEnabled);
     m_settings.setValue(QStringLiteral("showZoomInHeader"), m_showZoomInHeader);
     m_settings.setValue(QStringLiteral("globalMute"), m_globalMute);
+    m_settings.setValue(QStringLiteral("hideHeader"), m_hideHeader);
     m_settings.endGroup();
 
     m_settings.sync();
@@ -692,6 +707,7 @@ void ConfigManager::loadSettings()
     m_systemTrayEnabled = m_settings.value(QStringLiteral("systemTrayEnabled"), true).toBool();
     m_showZoomInHeader = m_settings.value(QStringLiteral("showZoomInHeader"), true).toBool();
     m_globalMute = m_settings.value(QStringLiteral("globalMute"), false).toBool();
+    m_hideHeader = m_settings.value(QStringLiteral("hideHeader"), false).toBool();
     m_settings.endGroup();
 
     // Only update workspaces list if it's empty (first run)

--- a/src/core/configmanager.h
+++ b/src/core/configmanager.h
@@ -25,6 +25,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool confirmDownloads READ confirmDownloads WRITE setConfirmDownloads NOTIFY confirmDownloadsChanged)
     Q_PROPERTY(bool systemTrayEnabled READ systemTrayEnabled WRITE setSystemTrayEnabled NOTIFY systemTrayEnabledChanged)
     Q_PROPERTY(bool showZoomInHeader READ showZoomInHeader WRITE setShowZoomInHeader NOTIFY showZoomInHeaderChanged)
+    Q_PROPERTY(bool hideHeader READ hideHeader WRITE setHideHeader NOTIFY hideHeaderChanged)
 
 public:
     explicit ConfigManager(QObject *parent = nullptr);
@@ -93,6 +94,10 @@ public:
     bool showZoomInHeader() const;
     void setShowZoomInHeader(bool enabled);
 
+    // Hide the application header (Kirigami page toolbar). Toggleable via Ctrl+H.
+    bool hideHeader() const;
+    void setHideHeader(bool enabled);
+
     Q_INVOKABLE void saveSettings();
     Q_INVOKABLE void loadSettings();
 
@@ -130,6 +135,7 @@ Q_SIGNALS:
     void confirmDownloadsChanged();
     void systemTrayEnabledChanged();
     void showZoomInHeaderChanged();
+    void hideHeaderChanged();
 
 private:
     void updateWorkspacesList();
@@ -150,6 +156,7 @@ private:
     bool m_confirmDownloads = true;
     bool m_systemTrayEnabled = true;
     bool m_showZoomInHeader = true;
+    bool m_hideHeader = false;
 };
 
 #endif // CONFIGMANAGER_H

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -574,11 +574,14 @@ Kirigami.ApplicationWindow {
         id: drawer
         workspaces: root.workspaces
         currentWorkspace: root.currentWorkspace
-        // Hide the floating auto-handle only when the application header is
-        // hidden AND the sidebar is hosting an integrated hamburger slot. In
-        // every other case keep Kirigami's default handle behaviour intact —
-        // including the hamburger that lives inside the header itself.
-        handleVisible: !(configManager && configManager.hideHeader && root.filteredServices.length > 0)
+        // Hide the floating auto-handle only when the drawer is closed, the
+        // application header is hidden, and the sidebar is hosting our own
+        // integrated hamburger slot. Keep the handle visible whenever the
+        // drawer is open so its standard "Close Drawer" affordance still
+        // sits at the drawer's edge as Kirigami expects, and keep the
+        // default header hamburger intact in every other state.
+        handleVisible: drawer.drawerOpen
+            || !(configManager && configManager.hideHeader && root.filteredServices.length > 0)
         onSwitchToWorkspace: function (name) {
             root.switchToWorkspace(name);
         }

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -19,6 +19,12 @@ Kirigami.ApplicationWindow {
     width: 1200
     height: 800
 
+    // Hide the Kirigami page toolbar (the application header) on demand.
+    // Bound to configManager so the choice persists. Toggled with Ctrl+H.
+    pageStack.globalToolBar.style: configManager && configManager.hideHeader
+        ? Kirigami.ApplicationHeaderStyle.None
+        : Kirigami.ApplicationHeaderStyle.Auto
+
     property int buttonSize: 64
     property int iconSize: 64 - Kirigami.Units.smallSpacing * 4
     property int sidebarWidth: buttonSize + Kirigami.Units.smallSpacing * 2
@@ -556,14 +562,23 @@ Kirigami.ApplicationWindow {
 
     // Window title
     // i18nc() makes a string translatable
-    // and provides additional context for the translators
-    title: i18nc("@title:window", "Unify")
+    // and provides additional context for the translators.
+    // When the application header is hidden the active service name is appended
+    // so the user keeps a visual cue of which service is in the foreground.
+    title: configManager && configManager.hideHeader && root.currentServiceId !== ""
+        ? i18nc("@title:window", "Unify - %1", root.currentServiceName)
+        : i18nc("@title:window", "Unify")
 
     // Global drawer (hamburger menu)
     globalDrawer: WorkspaceDrawer {
         id: drawer
         workspaces: root.workspaces
         currentWorkspace: root.currentWorkspace
+        // Hide the floating auto-handle only when the application header is
+        // hidden AND the sidebar is hosting an integrated hamburger slot. In
+        // every other case keep Kirigami's default handle behaviour intact —
+        // including the hamburger that lives inside the header itself.
+        handleVisible: !(configManager && configManager.hideHeader && root.filteredServices.length > 0)
         onSwitchToWorkspace: function (name) {
             root.switchToWorkspace(name);
         }
@@ -1040,6 +1055,8 @@ Kirigami.ApplicationWindow {
                         sidebarWidth: root.sidebarWidth
                         buttonSize: root.buttonSize
                         iconSize: root.iconSize
+                        showHamburger: configManager && configManager.hideHeader
+                        onHamburgerClicked: drawer.open()
                         onServiceSelected: function (id) {
                             root.switchToService(id);
                             var svc = root.findServiceById(id);
@@ -1186,6 +1203,8 @@ Kirigami.ApplicationWindow {
                     sidebarWidth: root.sidebarWidth
                     buttonSize: root.buttonSize
                     iconSize: root.iconSize
+                    showHamburger: configManager && configManager.hideHeader
+                    onHamburgerClicked: drawer.open()
                     onServiceSelected: function (id) {
                         root.switchToService(id);
                         var svc = root.findServiceById(id);
@@ -1393,6 +1412,17 @@ Kirigami.ApplicationWindow {
         onActivated: {
             if (root.currentServiceId !== "" && root.webViewStack) {
                 root.webViewStack.refreshByServiceId(root.currentServiceId);
+            }
+        }
+    }
+
+    // Toggle the application header visibility with Ctrl+H
+    Shortcut {
+        sequences: ["Ctrl+H"]
+        context: Qt.ApplicationShortcut
+        onActivated: {
+            if (configManager) {
+                configManager.hideHeader = !configManager.hideHeader;
             }
         }
     }

--- a/src/qml/components/ServicesSidebar.qml
+++ b/src/qml/components/ServicesSidebar.qml
@@ -24,6 +24,10 @@ Rectangle {
 
     property int favoriteVersion: 0
 
+    // When true, an integrated hamburger slot is appended to the sidebar so the
+    // global drawer remains reachable while the application header is hidden.
+    property bool showHamburger: false
+
     signal serviceSelected(string id)
     signal editServiceRequested(string id)
     signal moveServiceUp(string id)
@@ -33,6 +37,7 @@ Rectangle {
     signal detachService(string id)
     signal toggleFavoriteRequested(string id)
     signal toggleMuteRequested(string id)
+    signal hamburgerClicked()
 
     Connections {
         target: typeof configManager !== "undefined" ? configManager : null
@@ -52,9 +57,19 @@ Rectangle {
     Controls.ScrollView {
         id: scrollView
         anchors.fill: parent
+        // When the integrated hamburger slot is visible, reserve space for it
+        // along the relevant edge so the scrollable services don't overlap.
         anchors.topMargin: horizontal ? 0 : Kirigami.Units.smallSpacing
-        anchors.bottomMargin: horizontal ? 0 : Kirigami.Units.smallSpacing
-        anchors.leftMargin: horizontal ? Kirigami.Units.smallSpacing : 0
+        anchors.bottomMargin: horizontal
+            ? 0
+            : (root.showHamburger
+               ? root.buttonSize + Kirigami.Units.smallSpacing
+               : Kirigami.Units.smallSpacing)
+        anchors.leftMargin: horizontal
+            ? (root.showHamburger
+               ? root.buttonSize + Kirigami.Units.smallSpacing
+               : Kirigami.Units.smallSpacing)
+            : 0
         anchors.rightMargin: horizontal ? Kirigami.Units.smallSpacing : 0
 
         Controls.ScrollBar.vertical.policy: Controls.ScrollBar.AlwaysOff
@@ -309,6 +324,42 @@ Rectangle {
                     }
                 }
             }
+        }
+    }
+
+    // Integrated hamburger slot — only present while the application header
+    // is hidden. Pinned to the bottom (vertical) or left (horizontal) of the
+    // sidebar so it reads as another sidebar slot rather than a floating
+    // handle. Sized to match the service icons.
+    Item {
+        id: hamburgerSlot
+        visible: root.showHamburger
+        width: root.buttonSize
+        height: root.buttonSize
+
+        anchors.bottom: root.horizontal ? undefined : parent.bottom
+        anchors.horizontalCenter: root.horizontal ? undefined : parent.horizontalCenter
+        anchors.bottomMargin: root.horizontal ? 0 : Kirigami.Units.smallSpacing
+
+        anchors.left: root.horizontal ? parent.left : undefined
+        anchors.verticalCenter: root.horizontal ? parent.verticalCenter : undefined
+        anchors.leftMargin: root.horizontal ? Kirigami.Units.smallSpacing : 0
+
+        Controls.ToolButton {
+            anchors.fill: parent
+            icon.name: "application-menu"
+            // Cap the icon at the standard header size so the menu glyph keeps
+            // a familiar visual weight regardless of the sidebar size preset.
+            icon.width: Math.min(root.iconSize, Kirigami.Units.iconSizes.smallMedium)
+            icon.height: Math.min(root.iconSize, Kirigami.Units.iconSizes.smallMedium)
+            display: Controls.AbstractButton.IconOnly
+            // In a vertical sidebar rotate the glyph 90° so the dots read as
+            // a horizontal triplet — perpendicular to the bar's direction.
+            rotation: root.horizontal ? 0 : 90
+            onClicked: root.hamburgerClicked()
+            Controls.ToolTip.text: i18nc("@info:tooltip", "Menu")
+            Controls.ToolTip.visible: hovered
+            Controls.ToolTip.delay: Kirigami.Units.toolTipDelay
         }
     }
 

--- a/src/qml/components/ServicesSidebar.qml
+++ b/src/qml/components/ServicesSidebar.qml
@@ -353,9 +353,6 @@ Rectangle {
             icon.width: Math.min(root.iconSize, Kirigami.Units.iconSizes.smallMedium)
             icon.height: Math.min(root.iconSize, Kirigami.Units.iconSizes.smallMedium)
             display: Controls.AbstractButton.IconOnly
-            // In a vertical sidebar rotate the glyph 90° so the dots read as
-            // a horizontal triplet — perpendicular to the bar's direction.
-            rotation: root.horizontal ? 0 : 90
             onClicked: root.hamburgerClicked()
             Controls.ToolTip.text: i18nc("@info:tooltip", "Menu")
             Controls.ToolTip.visible: hovered

--- a/src/qml/drawers/WorkspaceDrawer.qml
+++ b/src/qml/drawers/WorkspaceDrawer.qml
@@ -202,6 +202,22 @@ Kirigami.Action { separator: true }
             }
         `, drawer));
 
+        // Hide Header toggle (Ctrl+H)
+        acts.push(Qt.createQmlObject(`
+            import org.kde.kirigami as Kirigami
+            Kirigami.Action {
+              text: i18n("Hide Header (Ctrl+H)")
+              icon.name: "view-hidden"
+              checkable: true
+              checked: configManager && configManager.hideHeader
+              onTriggered: {
+                  if (configManager) {
+                      configManager.hideHeader = !configManager.hideHeader
+                  }
+              }
+            }
+        `, drawer));
+
         // separator
         acts.push(Qt.createQmlObject(`import org.kde.kirigami as Kirigami
 Kirigami.Action { separator: true }


### PR DESCRIPTION
**Tech approach.** Adds `hideHeader` to `ConfigManager`, binds `pageStack.globalToolBar.style` to it, appends the active service name to the window title while hidden, and wires `Ctrl+H` plus a drawer toggle. Drawer access while the header is gone is preserved by appending an integrated hamburger slot to `ServicesSidebar` (square, icon capped at `iconSizes.smallMedium`, rotated 90° in vertical mode); Kirigami's auto-handle is suppressed only when the drawer is closed AND that integrated slot is showing, so the standard header hamburger and the open-drawer close affordance keep their default position elsewhere.