### PR TITLE
feat(autostart): add Launch on System Start toggle via Background portal

### DIFF
--- a/po/Unify.pot
+++ b/po/Unify.pot
@@ -309,6 +309,11 @@ msgstr ""
 msgid "${ws}"
 msgstr ""
 
+#: src/qml/drawers/WorkspaceDrawer.qml:170
+#, kde-format
+msgid "Launch on System Start"
+msgstr ""
+
 #: src/trayiconmanager.cpp:57
 #, kde-format
 msgid "Show Unify"

--- a/po/es.po
+++ b/po/es.po
@@ -316,6 +316,11 @@ msgstr ""
 msgid "${ws}"
 msgstr "${ws}"
 
+#: src/qml/drawers/WorkspaceDrawer.qml:170
+#, kde-format
+msgid "Launch on System Start"
+msgstr "Iniciar al arrancar el sistema"
+
 #: src/trayiconmanager.cpp:57
 #, kde-format
 msgid "Show Unify"

--- a/po/nl.po
+++ b/po/nl.po
@@ -315,6 +315,11 @@ msgstr ""
 msgid "${ws}"
 msgstr "${ws}"
 
+#: src/qml/drawers/WorkspaceDrawer.qml:170
+#, kde-format
+msgid "Launch on System Start"
+msgstr ""
+
 #: src/trayiconmanager.cpp:57
 #, kde-format
 msgid "Show Unify"

--- a/src/core/configmanager.cpp
+++ b/src/core/configmanager.cpp
@@ -1,10 +1,55 @@
 #include "configmanager.h"
+#include <QCoreApplication>
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusObjectPath>
+#include <QDBusReply>
 #include <QDebug>
 #include <QUuid>
 
 // Define special workspace constants
 const QString ConfigManager::FAVORITES_WORKSPACE = QStringLiteral("__favorites__");
 const QString ConfigManager::ALL_SERVICES_WORKSPACE = QStringLiteral("__all_services__");
+
+namespace
+{
+// Build the commandline the desktop session should run on login. Inside Flatpak
+// the in-sandbox application path is unreachable from the host session, so the
+// portal needs `flatpak run` instead.
+QStringList autostartCommandLine()
+{
+    if (qEnvironmentVariableIsSet("FLATPAK_ID")) {
+        return {QStringLiteral("flatpak"), QStringLiteral("run"), QStringLiteral("io.github.denysmb.unify")};
+    }
+    return {QCoreApplication::applicationFilePath()};
+}
+
+// Ask org.freedesktop.portal.Background to (un)register us for autostart. The
+// portal works inside Flatpak (where ~/.config/autostart isn't writable from
+// the sandbox) and on native installs alike, so this is the single code path.
+bool requestBackgroundPortal(bool autostart)
+{
+    QDBusMessage msg = QDBusMessage::createMethodCall(QStringLiteral("org.freedesktop.portal.Desktop"),
+                                                      QStringLiteral("/org/freedesktop/portal/desktop"),
+                                                      QStringLiteral("org.freedesktop.portal.Background"),
+                                                      QStringLiteral("RequestBackground"));
+
+    QVariantMap options;
+    options.insert(QStringLiteral("autostart"), autostart);
+    options.insert(QStringLiteral("reason"), QStringLiteral("Launch Unify on system start"));
+    options.insert(QStringLiteral("commandline"), autostartCommandLine());
+
+    msg << QString() // parent_window: empty — no parent dialog handle
+        << options;
+
+    QDBusReply<QDBusObjectPath> reply = QDBusConnection::sessionBus().call(msg);
+    if (!reply.isValid()) {
+        qWarning() << "Background portal RequestBackground failed:" << reply.error().message();
+        return false;
+    }
+    return true;
+}
+} // namespace
 
 ConfigManager::ConfigManager(QObject *parent)
     : QObject(parent)
@@ -344,6 +389,26 @@ void ConfigManager::setShowZoomInHeader(bool enabled)
     }
 }
 
+bool ConfigManager::autostartEnabled() const
+{
+    return m_autostartEnabled;
+}
+
+void ConfigManager::setAutostartEnabled(bool enabled)
+{
+    if (m_autostartEnabled == enabled) {
+        return;
+    }
+
+    if (!requestBackgroundPortal(enabled)) {
+        return;
+    }
+
+    m_autostartEnabled = enabled;
+    Q_EMIT autostartEnabledChanged();
+    saveSettings();
+}
+
 void ConfigManager::addService(const QVariantMap &service)
 {
     QVariantMap newService = service;
@@ -625,6 +690,7 @@ void ConfigManager::saveSettings()
     m_settings.setValue(QStringLiteral("systemTrayEnabled"), m_systemTrayEnabled);
     m_settings.setValue(QStringLiteral("showZoomInHeader"), m_showZoomInHeader);
     m_settings.setValue(QStringLiteral("globalMute"), m_globalMute);
+    m_settings.setValue(QStringLiteral("autostartEnabled"), m_autostartEnabled);
     m_settings.endGroup();
 
     m_settings.sync();
@@ -692,6 +758,7 @@ void ConfigManager::loadSettings()
     m_systemTrayEnabled = m_settings.value(QStringLiteral("systemTrayEnabled"), true).toBool();
     m_showZoomInHeader = m_settings.value(QStringLiteral("showZoomInHeader"), true).toBool();
     m_globalMute = m_settings.value(QStringLiteral("globalMute"), false).toBool();
+    m_autostartEnabled = m_settings.value(QStringLiteral("autostartEnabled"), false).toBool();
     m_settings.endGroup();
 
     // Only update workspaces list if it's empty (first run)

--- a/src/core/configmanager.h
+++ b/src/core/configmanager.h
@@ -25,6 +25,7 @@ class ConfigManager : public QObject
     Q_PROPERTY(bool confirmDownloads READ confirmDownloads WRITE setConfirmDownloads NOTIFY confirmDownloadsChanged)
     Q_PROPERTY(bool systemTrayEnabled READ systemTrayEnabled WRITE setSystemTrayEnabled NOTIFY systemTrayEnabledChanged)
     Q_PROPERTY(bool showZoomInHeader READ showZoomInHeader WRITE setShowZoomInHeader NOTIFY showZoomInHeaderChanged)
+    Q_PROPERTY(bool autostartEnabled READ autostartEnabled WRITE setAutostartEnabled NOTIFY autostartEnabledChanged)
 
 public:
     explicit ConfigManager(QObject *parent = nullptr);
@@ -93,6 +94,12 @@ public:
     bool showZoomInHeader() const;
     void setShowZoomInHeader(bool enabled);
 
+    // Autostart: writes/removes a .desktop file in ~/.config/autostart/ so
+    // the desktop session launches Unify on login. The source of truth is the
+    // filesystem (no QSettings entry) — read by checking file existence.
+    bool autostartEnabled() const;
+    void setAutostartEnabled(bool enabled);
+
     Q_INVOKABLE void saveSettings();
     Q_INVOKABLE void loadSettings();
 
@@ -130,6 +137,7 @@ Q_SIGNALS:
     void confirmDownloadsChanged();
     void systemTrayEnabledChanged();
     void showZoomInHeaderChanged();
+    void autostartEnabledChanged();
 
 private:
     void updateWorkspacesList();
@@ -150,6 +158,7 @@ private:
     bool m_confirmDownloads = true;
     bool m_systemTrayEnabled = true;
     bool m_showZoomInHeader = true;
+    bool m_autostartEnabled = false;
 };
 
 #endif // CONFIGMANAGER_H

--- a/src/qml/drawers/WorkspaceDrawer.qml
+++ b/src/qml/drawers/WorkspaceDrawer.qml
@@ -164,6 +164,22 @@ Kirigami.Action { separator: true }
             }
         `, drawer));
 
+        // Launch on System Start toggle
+        acts.push(Qt.createQmlObject(`
+            import org.kde.kirigami as Kirigami
+            Kirigami.Action {
+              text: i18n("Launch on System Start")
+              icon.name: "system-run-symbolic"
+              checkable: true
+              checked: configManager && configManager.autostartEnabled
+              onTriggered: {
+                  if (configManager) {
+                      configManager.autostartEnabled = !configManager.autostartEnabled
+                  }
+              }
+            }
+        `, drawer));
+
         // Mute All toggle
         acts.push(Qt.createQmlObject(`
             import org.kde.kirigami as Kirigami


### PR DESCRIPTION
**Tech approach.** Adds `autostartEnabled` to `ConfigManager` backed by a `org.freedesktop.portal.Background.RequestBackground` call — single code path, works inside Flatpak (where `~/.config/autostart` is sandboxed off the host session) and on native installs alike, with no manifest change. The commandline registered with the portal is `flatpak run io.github.denysmb.unify` when `FLATPAK_ID` is set, otherwise `QCoreApplication::applicationFilePath()`; intent persists in `QSettings` since the portal has no `GetStatus` method.