### PR TITLE
feat(KOD-9): Move settings to dedicated settings window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 cmake_minimum_required(VERSION 3.20)
-project(Unify VERSION 0.6.0)
+project(Unify VERSION 0.7.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/io.github.denysmb.unify.metainfo.xml
+++ b/io.github.denysmb.unify.metainfo.xml
@@ -69,6 +69,19 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.7.0" date="2026-05-23">
+      <description>
+        <p>This release introduces a dedicated Settings window, moving all configuration options out of the workspace drawer for a cleaner and more organized experience:</p>
+        <ul>
+          <li>Added dedicated Settings window with categorized sections (Appearance, Behavior, Widevine)</li>
+          <li>Appearance settings: sidebar orientation, size presets, header visibility, zoom controls, workspaces bar</li>
+          <li>Behavior settings: global mute, download confirmation, system tray, autostart</li>
+          <li>Widevine DRM management with install/uninstall UI</li>
+          <li>Workspace drawer simplified to show only workspace navigation and quick actions</li>
+          <li>Settings follow KDE HIG with proper FormLayout structure</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.6.0" date="2026-05-14">
       <description>
         <p>This release adds sidebar customization, header visibility control, and autostart support:</p>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,12 @@ ecm_target_qml_sources(unify
     qml/dialogs/PermissionDialog.qml
     qml/dialogs/WorkspaceDialog.qml
     qml/dialogs/DesktopMediaDialog.qml
+    qml/dialogs/TipsDialog.qml
     qml/drawers/WorkspaceDrawer.qml
+    qml/settings/SettingsPage.qml
+    qml/settings/SettingsAppearance.qml
+    qml/settings/SettingsBehavior.qml
+    qml/settings/SettingsWidevine.qml
     qml/utils/Services.js
     qml/utils/AntiDetection.js
 )

--- a/src/qml/Main.qml
+++ b/src/qml/Main.qml
@@ -620,6 +620,27 @@ Kirigami.ApplicationWindow {
                 addWorkspaceDialog.open();
             }
         }
+        onSettingsRequested: root.openSettings()
+        onTipsRequested: tipsDialog.open()
+    }
+
+    Component {
+        id: settingsPageComponent
+        SettingsPage {}
+    }
+
+    TipsDialog {
+        id: tipsDialog
+    }
+
+    function openSettings() {
+        applicationWindow().pageStack.pushDialogLayer(settingsPageComponent, {}, {
+            title: i18n("Settings"),
+            width: 600,
+            height: 550,
+            minimumWidth: 600,
+            minimumHeight: 550
+        });
     }
 
     // Add/Edit Service Dialog

--- a/src/qml/dialogs/TipsDialog.qml
+++ b/src/qml/dialogs/TipsDialog.qml
@@ -1,0 +1,79 @@
+import QtQuick
+import QtQuick.Controls as QQC2
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+Kirigami.Dialog {
+    id: root
+
+    title: i18n("Tips & Settings")
+    padding: Kirigami.Units.largeSpacing
+    preferredWidth: Kirigami.Units.gridUnit * 30
+    standardButtons: Kirigami.Dialog.Ok
+
+    QQC2.ScrollView {
+        implicitWidth: Kirigami.Units.gridUnit * 28
+        implicitHeight: Kirigami.Units.gridUnit * 24
+
+        ColumnLayout {
+            width: parent.width
+            spacing: Kirigami.Units.largeSpacing
+
+            Kirigami.Heading {
+                level: 4
+                text: i18n("Keyboard Shortcuts")
+            }
+
+            QQC2.Label {
+                Layout.fillWidth: true
+                wrapMode: QQC2.Label.WordWrap
+                textFormat: QQC2.Label.RichText
+                text: i18n("<b>Ctrl + 1, 2, 3...</b> — Switch between services in the current workspace<br>" +
+                    "<b>Ctrl + Shift + 1, 2, 3...</b> — Switch between workspaces<br>" +
+                    "<b>Ctrl + B</b> — Go to Favorites workspace<br>" +
+                    "<b>Ctrl + Tab</b> — Go to the next service<br>" +
+                    "<b>Ctrl + Shift + Tab</b> — Go to the next workspace<br>" +
+                    "<b>Double-tap Ctrl</b> — Toggle between the last two services<br>" +
+                    "<b>Escape</b> — Close overlay/dialog")
+            }
+
+            Kirigami.Separator {
+                Layout.fillWidth: true
+            }
+
+            Kirigami.Heading {
+                level: 4
+                text: i18n("Link Handling")
+            }
+
+            QQC2.Label {
+                Layout.fillWidth: true
+                wrapMode: QQC2.Label.WordWrap
+                textFormat: QQC2.Label.RichText
+                text: i18n("When you click a link in a service, it opens in an <b>overlay</b> where you can choose to:<br>" +
+                    "• <b>Open in Service</b> — Navigate the service to that URL<br>" +
+                    "• <b>Open in Browser</b> — Open in your default browser<br><br>" +
+                    "<b>Tip:</b> Hold <b>Ctrl</b> while clicking a link to open it directly in your browser, bypassing the overlay.")
+            }
+
+            Kirigami.Separator {
+                Layout.fillWidth: true
+            }
+
+            Kirigami.Heading {
+                level: 4
+                text: i18n("Other Tips")
+            }
+
+            QQC2.Label {
+                Layout.fillWidth: true
+                wrapMode: QQC2.Label.WordWrap
+                textFormat: QQC2.Label.RichText
+                text: i18n("• <b>Right-click</b> a service icon to access quick actions (edit, disable, delete)<br>" +
+                    "• <b>Disabled services</b> won't load until re-enabled, saving resources<br>" +
+                    "• Enable <b>System Tray</b> to keep the app running in the background when you close the window<br>" +
+                    "• <b>Notification badges</b> appear on service icons when there are unread messages")
+            }
+        }
+    }
+}

--- a/src/qml/drawers/WorkspaceDrawer.qml
+++ b/src/qml/drawers/WorkspaceDrawer.qml
@@ -6,7 +6,6 @@ import org.kde.kirigami as Kirigami
 Kirigami.GlobalDrawer {
     id: drawer
 
-    // Public API
     property var workspaces: []
     property string currentWorkspace: ""
 
@@ -14,11 +13,11 @@ Kirigami.GlobalDrawer {
     signal addWorkspaceRequested
     signal editWorkspaceRequested(int index)
     signal tipsRequested
+    signal settingsRequested
 
     function buildActions() {
         var acts = [];
 
-        // Special workspaces at the top
         acts.push(Qt.createQmlObject(`
             import org.kde.kirigami as Kirigami
             Kirigami.Action {
@@ -41,13 +40,11 @@ Kirigami.GlobalDrawer {
             }
         `, drawer));
 
-        // Separator between special and regular workspaces
         acts.push(Qt.createQmlObject(`
             import org.kde.kirigami as Kirigami
             Kirigami.Action { separator: true }
         `, drawer));
 
-        // Regular workspaces
         for (var i = 0; i < workspaces.length; i++) {
             var ws = workspaces[i];
             acts.push(Qt.createQmlObject(`
@@ -62,12 +59,10 @@ Kirigami.GlobalDrawer {
             `, drawer));
         }
 
-        // separator
         acts.push(Qt.createQmlObject(`import org.kde.kirigami as Kirigami
 Kirigami.Action { separator: true }
 `, drawer));
 
-        // Edit Workspace (disabled for special workspaces)
         acts.push(Qt.createQmlObject(`
             import org.kde.kirigami as Kirigami
             Kirigami.Action {
@@ -78,7 +73,6 @@ Kirigami.Action { separator: true }
             }
         `, drawer));
 
-        // Add Workspace
         acts.push(Qt.createQmlObject(`
             import org.kde.kirigami as Kirigami
             Kirigami.Action {
@@ -88,208 +82,19 @@ Kirigami.Action { separator: true }
             }
         `, drawer));
 
-        // separator
         acts.push(Qt.createQmlObject(`import org.kde.kirigami as Kirigami
 Kirigami.Action { separator: true }
 `, drawer));
 
-        // Horizontal Sidebar toggle
         acts.push(Qt.createQmlObject(`
             import org.kde.kirigami as Kirigami
             Kirigami.Action {
-              text: i18n("Horizontal Sidebar")
-              icon.name: "object-rows"
-              checkable: true
-              checked: configManager && configManager.horizontalSidebar
-              onTriggered: {
-                  if (configManager) {
-                      configManager.horizontalSidebar = !configManager.horizontalSidebar
-                  }
-              }
+              text: i18n("Settings")
+              icon.name: "settings-configure"
+              onTriggered: drawer.settingsRequested()
             }
         `, drawer));
 
-        // Sidebar Size submenu (Tiny / Small / Normal / Big)
-        acts.push(Qt.createQmlObject(`
-            import org.kde.kirigami as Kirigami
-            Kirigami.Action {
-                text: i18n("Sidebar Size")
-                icon.name: "view-sort-symbolic"
-
-                Kirigami.Action {
-                    text: i18nc("Sidebar size preset", "Tiny")
-                    checkable: true
-                    checked: configManager && configManager.sidebarSizePreset === "tiny"
-                    onTriggered: {
-                        if (configManager) {
-                            configManager.sidebarSizePreset = "tiny"
-                        }
-                    }
-                }
-                Kirigami.Action {
-                    text: i18nc("Sidebar size preset", "Small")
-                    checkable: true
-                    checked: configManager && configManager.sidebarSizePreset === "small"
-                    onTriggered: {
-                        if (configManager) {
-                            configManager.sidebarSizePreset = "small"
-                        }
-                    }
-                }
-                Kirigami.Action {
-                    text: i18nc("Sidebar size preset", "Normal")
-                    checkable: true
-                    checked: configManager && configManager.sidebarSizePreset === "normal"
-                    onTriggered: {
-                        if (configManager) {
-                            configManager.sidebarSizePreset = "normal"
-                        }
-                    }
-                }
-                Kirigami.Action {
-                    text: i18nc("Sidebar size preset", "Big")
-                    checkable: true
-                    checked: configManager && configManager.sidebarSizePreset === "big"
-                    onTriggered: {
-                        if (configManager) {
-                            configManager.sidebarSizePreset = "big"
-                        }
-                    }
-                }
-            }
-        `, drawer));
-
-        // Show Workspaces Bar toggle
-        acts.push(Qt.createQmlObject(`
-            import org.kde.kirigami as Kirigami
-            Kirigami.Action {
-              text: i18n("Show Workspaces Bar")
-              icon.name: "view-file-columns"
-              checkable: true
-              checked: configManager && configManager.alwaysShowWorkspacesBar
-              onTriggered: {
-                  if (configManager) {
-                      configManager.alwaysShowWorkspacesBar = !configManager.alwaysShowWorkspacesBar
-                  }
-              }
-            }
-        `, drawer));
-
-        // Confirm Downloads toggle
-        acts.push(Qt.createQmlObject(`
-            import org.kde.kirigami as Kirigami
-            Kirigami.Action {
-              text: i18n("Confirm Downloads")
-              icon.name: "download-later"
-              checkable: true
-              checked: configManager && configManager.confirmDownloads
-              onTriggered: {
-                  if (configManager) {
-                      configManager.confirmDownloads = !configManager.confirmDownloads
-                  }
-              }
-            }
-        `, drawer));
-
-        // System Tray toggle
-        acts.push(Qt.createQmlObject(`
-            import org.kde.kirigami as Kirigami
-            Kirigami.Action {
-              text: configManager && configManager.systemTrayEnabled ? i18n("Hide Tray Icon") : i18n("Show Tray Icon")
-              icon.name: configManager && configManager.systemTrayEnabled ? "object-hidden" : "object-visible"
-              checkable: true
-              checked: configManager && configManager.systemTrayEnabled
-              onTriggered: {
-                  if (configManager) {
-                      configManager.systemTrayEnabled = !configManager.systemTrayEnabled
-                  }
-                  if (trayIconManager) {
-                      if (configManager && configManager.systemTrayEnabled) {
-                          trayIconManager.show()
-                      } else {
-                          trayIconManager.hide()
-                      }
-                  }
-              }
-            }
-        `, drawer));
-
-        // Launch on System Start toggle
-        acts.push(Qt.createQmlObject(`
-            import org.kde.kirigami as Kirigami
-            Kirigami.Action {
-              text: i18n("Launch on System Start")
-              icon.name: "system-run-symbolic"
-              checkable: true
-              checked: configManager && configManager.autostartEnabled
-              onTriggered: {
-                  if (configManager) {
-                      configManager.autostartEnabled = !configManager.autostartEnabled
-                  }
-              }
-            }
-        `, drawer));
-
-        // Mute All toggle
-        acts.push(Qt.createQmlObject(`
-            import org.kde.kirigami as Kirigami
-            Kirigami.Action {
-              text: configManager && configManager.globalMute ? i18n("Unmute All") : i18n("Mute All")
-              icon.name: configManager && configManager.globalMute ? "player-volume" : "player-volume-muted"
-              checkable: true
-              checked: configManager && configManager.globalMute
-              onTriggered: {
-                  if (configManager) {
-                      configManager.globalMute = !configManager.globalMute
-                  }
-              }
-            }
-        `, drawer));
-
-        // Show Zoom in Header toggle
-        acts.push(Qt.createQmlObject(`
-            import org.kde.kirigami as Kirigami
-            Kirigami.Action {
-              text: i18n("Show Zoom Controls")
-              icon.name: "zoom-select"
-              checkable: true
-              checked: configManager && configManager.showZoomInHeader
-              onTriggered: {
-                  if (configManager) {
-                      configManager.showZoomInHeader = !configManager.showZoomInHeader
-                      if (!configManager.showZoomInHeader && drawer.Kirigami.ApplicationWindow.window) {
-                          drawer.Kirigami.ApplicationWindow.window.showPassiveNotification(
-                              i18n("You can still zoom using Ctrl + Mouse Scroll"),
-                              3000
-                          )
-                      }
-                  }
-              }
-            }
-        `, drawer));
-
-        // Hide Header toggle (Ctrl+H)
-        acts.push(Qt.createQmlObject(`
-            import org.kde.kirigami as Kirigami
-            Kirigami.Action {
-              text: i18n("Hide Header (Ctrl+H)")
-              icon.name: "view-hidden"
-              checkable: true
-              checked: configManager && configManager.hideHeader
-              onTriggered: {
-                  if (configManager) {
-                      configManager.hideHeader = !configManager.hideHeader
-                  }
-              }
-            }
-        `, drawer));
-
-        // separator
-        acts.push(Qt.createQmlObject(`import org.kde.kirigami as Kirigami
-Kirigami.Action { separator: true }
-`, drawer));
-
-        // Tips
         acts.push(Qt.createQmlObject(`
             import org.kde.kirigami as Kirigami
             Kirigami.Action {
@@ -302,192 +107,5 @@ Kirigami.Action { separator: true }
         return acts;
     }
 
-    // Keep as binding so changes in workspaces rebuild the list
     actions: buildActions()
-
-    Kirigami.Dialog {
-        id: tipsDialog
-        title: i18n("Tips & Settings")
-        padding: Kirigami.Units.largeSpacing
-        preferredWidth: Kirigami.Units.gridUnit * 30
-        standardButtons: Kirigami.Dialog.Ok
-
-        QQC2.ScrollView {
-            implicitWidth: Kirigami.Units.gridUnit * 28
-            implicitHeight: Kirigami.Units.gridUnit * 24
-
-            ColumnLayout {
-                width: parent.width
-                spacing: Kirigami.Units.largeSpacing
-
-                // DRM Content Section
-                Kirigami.Heading {
-                    level: 4
-                    text: i18n("DRM Content (Widevine)")
-                }
-
-                QQC2.Label {
-                    Layout.preferredWidth: parent.width - 20
-                    Layout.fillWidth: true
-                    wrapMode: QQC2.Label.WordWrap
-                    text: i18n("Some streaming services (Spotify, Netflix, Prime Video, etc.) require Widevine CDM to play DRM-protected content.")
-                }
-
-                QQC2.Label {
-                    Layout.preferredWidth: parent.width - 20
-                    Layout.fillWidth: true
-                    wrapMode: QQC2.Label.WordWrap
-                    text: i18n("Widevine is a Google proprietary library that cannot be bundled with the app.")
-                }
-
-                // Status indicator
-                RowLayout {
-                    Layout.fillWidth: true
-                    spacing: Kirigami.Units.smallSpacing
-
-                    Kirigami.Icon {
-                        source: widevineManager && widevineManager.isInstalled ? "dialog-ok-apply" : "dialog-warning"
-                        color: widevineManager && widevineManager.isInstalled ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.neutralTextColor
-                        Layout.preferredWidth: Kirigami.Units.iconSizes.small
-                        Layout.preferredHeight: Kirigami.Units.iconSizes.small
-                    }
-
-                    QQC2.Label {
-                        Layout.fillWidth: true
-                        text: {
-                            if (!widevineManager) {
-                                return i18n("Status: Unknown");
-                            }
-                            if (widevineManager.isInstalling) {
-                                return i18n("Status: Installing...");
-                            }
-                            if (widevineManager.isInstalled) {
-                                return i18n("Status: Installed (version %1)", widevineManager.installedVersion);
-                            }
-                            return i18n("Status: Not installed");
-                        }
-                        color: widevineManager && widevineManager.isInstalled ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.neutralTextColor
-                    }
-                }
-
-                // Install/Uninstall buttons
-                RowLayout {
-                    Layout.fillWidth: true
-                    spacing: Kirigami.Units.smallSpacing
-
-                    QQC2.Button {
-                        text: widevineManager && widevineManager.isInstalled ? i18n("Reinstall Widevine") : i18n("Install Widevine")
-                        icon.name: "download"
-                        enabled: widevineManager && !widevineManager.isInstalling
-                        onClicked: {
-                            if (widevineManager) {
-                                widevineManager.install();
-                            }
-                        }
-
-                        QQC2.BusyIndicator {
-                            anchors.centerIn: parent
-                            running: widevineManager && widevineManager.isInstalling
-                            visible: running
-                        }
-                    }
-
-                    QQC2.Button {
-                        text: i18n("Uninstall")
-                        icon.name: "edit-delete"
-                        visible: widevineManager && widevineManager.isInstalled
-                        enabled: widevineManager && !widevineManager.isInstalling
-                        onClicked: {
-                            if (widevineManager) {
-                                widevineManager.uninstall();
-                            }
-                        }
-                    }
-                }
-
-                QQC2.Label {
-                    Layout.fillWidth: true
-                    wrapMode: QQC2.Label.WordWrap
-                    font.pointSize: Kirigami.Theme.smallFont.pointSize
-                    opacity: 0.7
-                    text: i18n("Note: After installing or uninstalling Widevine, you need to restart Unify for changes to take effect.")
-                }
-
-                Kirigami.Separator {
-                    Layout.fillWidth: true
-                }
-
-                // Keyboard Shortcuts Section
-                Kirigami.Heading {
-                    level: 4
-                    text: i18n("Keyboard Shortcuts")
-                }
-
-                QQC2.Label {
-                    Layout.fillWidth: true
-                    wrapMode: QQC2.Label.WordWrap
-                    textFormat: QQC2.Label.RichText
-                    text: i18n("<b>Ctrl + 1, 2, 3...</b> — Switch between services in the current workspace<br>" + "<b>Ctrl + Shift + 1, 2, 3...</b> — Switch between workspaces<br>" + "<b>Ctrl + B</b> — Go to Favorites workspace<br>" + "<b>Ctrl + Tab</b> — Go to the next service<br>" + "<b>Ctrl + Shift + Tab</b> — Go to the next workspace<br>" + "<b>Double-tap Ctrl</b> — Toggle between the last two services<br>" + "<b>Escape</b> — Close overlay/dialog")
-                }
-
-                Kirigami.Separator {
-                    Layout.fillWidth: true
-                }
-
-                Kirigami.Heading {
-                    level: 4
-                    text: i18n("Link Handling")
-                }
-
-                QQC2.Label {
-                    Layout.preferredWidth: parent.width - 20
-                    Layout.fillWidth: true
-                    wrapMode: QQC2.Label.WordWrap
-                    textFormat: QQC2.Label.RichText
-                    text: i18n("When you click a link in a service, it opens in an <b>overlay</b> where you can choose to:<br>" + "• <b>Open in Service</b> — Navigate the service to that URL<br>" + "• <b>Open in Browser</b> — Open in your default browser<br><br>" + "<b>Tip:</b> Hold <b>Ctrl</b> while clicking a link to open it directly in your browser, bypassing the overlay.")
-                }
-
-                Kirigami.Separator {
-                    Layout.fillWidth: true
-                }
-
-                Kirigami.Heading {
-                    level: 4
-                    text: i18n("Other Tips")
-                }
-
-                QQC2.Label {
-                    Layout.fillWidth: true
-                    wrapMode: QQC2.Label.WordWrap
-                    textFormat: QQC2.Label.RichText
-                    text: i18n("• <b>Right-click</b> a service icon to access quick actions (edit, disable, delete)<br>" + "• <b>Disabled services</b> won't load until re-enabled, saving resources<br>" + "• Enable <b>System Tray</b> to keep the app running in the background when you close the window<br>" + "• <b>Notification badges</b> appear on service icons when there are unread messages")
-                }
-            }
-        }
-    }
-
-    // Handle Widevine installation signals
-    Connections {
-        target: widevineManager
-        function onInstallationStarted() {
-            // Access showPassiveNotification from the root ApplicationWindow
-            if (drawer.Kirigami.ApplicationWindow.window) {
-                drawer.Kirigami.ApplicationWindow.window.showPassiveNotification(i18n("Widevine installation started. This may take a moment..."), "long");
-            }
-        }
-        function onInstallationFinished(success, message) {
-            if (drawer.Kirigami.ApplicationWindow.window) {
-                drawer.Kirigami.ApplicationWindow.window.showPassiveNotification(message, "long");
-            }
-        }
-        function onUninstallationFinished(success, message) {
-            if (drawer.Kirigami.ApplicationWindow.window) {
-                drawer.Kirigami.ApplicationWindow.window.showPassiveNotification(message, "long");
-            }
-        }
-    }
-
-    onTipsRequested: {
-        tipsDialog.open();
-    }
 }

--- a/src/qml/settings/SettingsAppearance.qml
+++ b/src/qml/settings/SettingsAppearance.qml
@@ -1,0 +1,106 @@
+import QtQuick
+import QtQuick.Controls as QQC2
+import QtQuick.Layouts
+
+import org.kde.kirigami as Kirigami
+
+Kirigami.ScrollablePage {
+    id: root
+
+    title: i18nc("@title", "Appearance")
+
+    Kirigami.ColumnView.fillWidth: true
+
+    Kirigami.FormLayout {
+        anchors.fill: parent
+
+        Kirigami.Separator {
+            Kirigami.FormData.label: i18nc("@title:group", "Sidebar:")
+            Kirigami.FormData.isSection: true
+        }
+
+        QQC2.CheckBox {
+            Kirigami.FormData.label: i18nc("@label:checkbox", "Horizontal Sidebar:")
+            text: i18nc("@option:check", "Place sidebar on top")
+            checked: configManager ? configManager.horizontalSidebar : false
+            onCheckedChanged: {
+                if (configManager) {
+                    configManager.horizontalSidebar = checked;
+                }
+            }
+        }
+
+        QQC2.ComboBox {
+            Kirigami.FormData.label: i18nc("@label:combobox", "Sidebar Size:")
+            model: [
+                { text: i18nc("Sidebar size preset", "Tiny"), value: "tiny" },
+                { text: i18nc("Sidebar size preset", "Small"), value: "small" },
+                { text: i18nc("Sidebar size preset", "Normal"), value: "normal" },
+                { text: i18nc("Sidebar size preset", "Big"), value: "big" }
+            ]
+            textRole: "text"
+            valueRole: "value"
+            currentIndex: {
+                var preset = configManager ? configManager.sidebarSizePreset : "normal";
+                for (var i = 0; i < model.length; i++) {
+                    if (model[i].value === preset) return i;
+                }
+                return 2;
+            }
+            onActivated: function (index) {
+                if (configManager) {
+                    configManager.sidebarSizePreset = model[index].value;
+                }
+            }
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.label: i18nc("@title:group", "Header:")
+            Kirigami.FormData.isSection: true
+        }
+
+        QQC2.CheckBox {
+            Kirigami.FormData.label: i18nc("@label:checkbox", "Hide Header:")
+            text: i18nc("@option:check", "Hide application header (Ctrl+H)")
+            checked: configManager ? configManager.hideHeader : false
+            onCheckedChanged: {
+                if (configManager) {
+                    configManager.hideHeader = checked;
+                }
+            }
+        }
+
+        QQC2.CheckBox {
+            Kirigami.FormData.label: i18nc("@label:checkbox", "Show Zoom Controls:")
+            text: i18nc("@option:check", "Zoom buttons in header")
+            checked: configManager ? configManager.showZoomInHeader : false
+            onCheckedChanged: {
+                if (configManager) {
+                    configManager.showZoomInHeader = checked;
+                    if (!checked) {
+                        applicationWindow().showPassiveNotification(
+                            i18n("You can still zoom using Ctrl + Mouse Scroll"),
+                            3000
+                        );
+                    }
+                }
+            }
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.label: i18nc("@title:group", "Workspaces:")
+            Kirigami.FormData.isSection: true
+        }
+
+        QQC2.CheckBox {
+            Kirigami.FormData.label: i18nc("@label:checkbox", "Show Workspaces Bar:")
+            text: i18nc("@option:check", "Always visible")
+            checked: configManager ? configManager.alwaysShowWorkspacesBar : false
+            onCheckedChanged: {
+                if (configManager) {
+                    configManager.alwaysShowWorkspacesBar = checked;
+                }
+            }
+        }
+    }
+}

--- a/src/qml/settings/SettingsBehavior.qml
+++ b/src/qml/settings/SettingsBehavior.qml
@@ -1,0 +1,101 @@
+import QtQuick
+import QtQuick.Controls as QQC2
+import QtQuick.Layouts
+
+import org.kde.kirigami as Kirigami
+
+Kirigami.ScrollablePage {
+    id: root
+
+    title: i18nc("@title", "Behavior")
+
+    Kirigami.ColumnView.fillWidth: true
+
+    Kirigami.FormLayout {
+        anchors.fill: parent
+
+        Kirigami.Separator {
+            Kirigami.FormData.label: i18nc("@title:group", "Audio:")
+            Kirigami.FormData.isSection: true
+        }
+
+        QQC2.CheckBox {
+            Kirigami.FormData.label: i18nc("@label:checkbox", "Mute All:")
+            text: configManager && configManager.globalMute
+                ? i18nc("@option:check", "All services are muted")
+                : i18nc("@option:check", "Mute all services at once")
+            checked: configManager ? configManager.globalMute : false
+            onCheckedChanged: {
+                if (configManager) {
+                    configManager.globalMute = checked;
+                }
+            }
+        }
+
+        QQC2.Label {
+            Layout.fillWidth: true
+            wrapMode: QQC2.Label.WordWrap
+            font: Kirigami.Theme.smallFont
+            color: Kirigami.Theme.disabledTextColor
+            text: i18n("When enabled, all services will be muted regardless of their individual mute state.")
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.label: i18nc("@title:group", "Downloads:")
+            Kirigami.FormData.isSection: true
+        }
+
+        QQC2.CheckBox {
+            Kirigami.FormData.label: i18nc("@label:checkbox", "Confirm Downloads:")
+            text: i18nc("@option:check", "Ask before downloading files")
+            checked: configManager ? configManager.confirmDownloads : false
+            onCheckedChanged: {
+                if (configManager) {
+                    configManager.confirmDownloads = checked;
+                }
+            }
+        }
+
+        QQC2.Label {
+            Layout.fillWidth: true
+            wrapMode: QQC2.Label.WordWrap
+            font: Kirigami.Theme.smallFont
+            color: Kirigami.Theme.disabledTextColor
+            text: i18n("When enabled, a confirmation dialog will appear before each download. When disabled, files are saved automatically to your Downloads folder.")
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.label: i18nc("@title:group", "System:")
+            Kirigami.FormData.isSection: true
+        }
+
+        QQC2.CheckBox {
+            Kirigami.FormData.label: i18nc("@label:checkbox", "System Tray:")
+            text: i18nc("@option:check", "Keep running in background")
+            checked: configManager ? configManager.systemTrayEnabled : false
+            onCheckedChanged: {
+                if (configManager) {
+                    configManager.systemTrayEnabled = checked;
+                }
+                if (trayIconManager) {
+                    if (checked) {
+                        trayIconManager.show();
+                    } else {
+                        trayIconManager.hide();
+                    }
+                }
+            }
+        }
+
+        QQC2.CheckBox {
+            Kirigami.FormData.label: i18nc("@label:checkbox", "Autostart:")
+            text: i18nc("@option:check", "Launch on system start")
+            checked: configManager ? configManager.autostartEnabled : false
+            onCheckedChanged: {
+                if (configManager) {
+                    configManager.autostartEnabled = checked;
+                }
+            }
+        }
+    }
+}

--- a/src/qml/settings/SettingsBehavior.qml
+++ b/src/qml/settings/SettingsBehavior.qml
@@ -32,14 +32,6 @@ Kirigami.ScrollablePage {
             }
         }
 
-        QQC2.Label {
-            Layout.fillWidth: true
-            wrapMode: QQC2.Label.WordWrap
-            font: Kirigami.Theme.smallFont
-            color: Kirigami.Theme.disabledTextColor
-            text: i18n("When enabled, all services will be muted regardless of their individual mute state.")
-        }
-
         Kirigami.Separator {
             Kirigami.FormData.label: i18nc("@title:group", "Downloads:")
             Kirigami.FormData.isSection: true
@@ -54,14 +46,6 @@ Kirigami.ScrollablePage {
                     configManager.confirmDownloads = checked;
                 }
             }
-        }
-
-        QQC2.Label {
-            Layout.fillWidth: true
-            wrapMode: QQC2.Label.WordWrap
-            font: Kirigami.Theme.smallFont
-            color: Kirigami.Theme.disabledTextColor
-            text: i18n("When enabled, a confirmation dialog will appear before each download. When disabled, files are saved automatically to your Downloads folder.")
         }
 
         Kirigami.Separator {

--- a/src/qml/settings/SettingsPage.qml
+++ b/src/qml/settings/SettingsPage.qml
@@ -1,0 +1,92 @@
+import QtQuick
+import QtQuick.Controls as QQC2
+import QtQuick.Layouts
+
+import org.kde.kirigami as Kirigami
+import org.kde.kirigamiaddons.formcard as FormCard
+
+Kirigami.ScrollablePage {
+    id: root
+
+    title: i18nc("@title", "Settings")
+
+    padding: 0
+
+    Kirigami.ColumnView.pinned: true
+    Kirigami.ColumnView.preferredWidth: Kirigami.Units.gridUnit * 18
+    Kirigami.ColumnView.minimumWidth: Kirigami.Units.gridUnit * 12
+    Kirigami.ColumnView.maximumWidth: Kirigami.Units.gridUnit * 22
+
+    Component {
+        id: appearancePage
+        SettingsAppearance {}
+    }
+
+    Component {
+        id: behaviorPage
+        SettingsBehavior {}
+    }
+
+    Component {
+        id: widevinePage
+        SettingsWidevine {}
+    }
+
+    FormCard.FormCard {
+        id: formCard
+        width: parent.width
+
+        states: [
+            State {
+                name: "centered"
+                when: !applicationWindow().pageStack.wideMode
+                AnchorChanges {
+                    target: formCard
+                    anchors.verticalCenter: formCard.parent.verticalCenter
+                }
+            },
+            State {
+                name: "top"
+                when: applicationWindow().pageStack.wideMode
+                AnchorChanges {
+                    target: formCard
+                    anchors.top: formCard.parent.top
+                }
+            }
+        ]
+
+        FormCard.FormButtonDelegate {
+            id: appearanceButton
+            text: i18nc("@action:button", "Appearance")
+            description: i18nc("@info:whatsthis", "Sidebar, header, and visual layout")
+            icon.name: "preferences-desktop-theme"
+            onClicked: Kirigami.PageStack.push(appearancePage)
+        }
+
+        FormCard.FormDelegateSeparator {
+            above: appearanceButton
+            below: behaviorButton
+        }
+
+        FormCard.FormButtonDelegate {
+            id: behaviorButton
+            text: i18nc("@action:button", "Behavior")
+            description: i18nc("@info:whatsthis", "Audio, downloads, tray, and autostart")
+            icon.name: "preferences-system"
+            onClicked: Kirigami.PageStack.push(behaviorPage)
+        }
+
+        FormCard.FormDelegateSeparator {
+            above: behaviorButton
+            below: widevineButton
+        }
+
+        FormCard.FormButtonDelegate {
+            id: widevineButton
+            text: i18nc("@action:button", "Widevine (DRM)")
+            description: i18nc("@info:whatsthis", "Install and manage Widevine CDM")
+            icon.name: "shield"
+            onClicked: Kirigami.PageStack.push(widevinePage)
+        }
+    }
+}

--- a/src/qml/settings/SettingsPage.qml
+++ b/src/qml/settings/SettingsPage.qml
@@ -85,7 +85,7 @@ Kirigami.ScrollablePage {
             id: widevineButton
             text: i18nc("@action:button", "Widevine (DRM)")
             description: i18nc("@info:whatsthis", "Install and manage Widevine CDM")
-            icon.name: "shield"
+            icon.name: "preferences-plugin"
             onClicked: Kirigami.PageStack.push(widevinePage)
         }
     }

--- a/src/qml/settings/SettingsWidevine.qml
+++ b/src/qml/settings/SettingsWidevine.qml
@@ -11,47 +11,37 @@ Kirigami.ScrollablePage {
 
     Kirigami.ColumnView.fillWidth: true
 
-    Kirigami.FormLayout {
+    ColumnLayout {
         anchors.fill: parent
+        anchors.margins: Kirigami.Units.largeSpacing
+        spacing: Kirigami.Units.largeSpacing
 
-        Kirigami.Separator {
-            Kirigami.FormData.label: i18nc("@title:group", "Status:")
-            Kirigami.FormData.isSection: true
+        QQC2.Label {
+            Layout.fillWidth: true
+            wrapMode: QQC2.Label.WordWrap
+            text: i18n("Some streaming services (Spotify, Netflix, Prime Video, etc.) require Widevine CDM to play DRM-protected content. Widevine is a Google proprietary library that cannot be bundled with the app.")
         }
 
-        RowLayout {
-            Kirigami.FormData.label: i18nc("@label", "Installation:")
-            spacing: Kirigami.Units.smallSpacing
+        Kirigami.InlineMessage {
+            Layout.fillWidth: true
+            type: widevineManager && widevineManager.isInstalled ? Kirigami.MessageType.Positive : Kirigami.MessageType.Information
+            icon.name: widevineManager && widevineManager.isInstalled ? "dialog-ok-apply" : "dialog-warning"
 
-            Kirigami.Icon {
-                source: widevineManager && widevineManager.isInstalled ? "dialog-ok-apply" : "dialog-warning"
-                color: widevineManager && widevineManager.isInstalled ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.neutralTextColor
-                Layout.preferredWidth: Kirigami.Units.iconSizes.small
-                Layout.preferredHeight: Kirigami.Units.iconSizes.small
-            }
-
-            QQC2.Label {
-                text: {
-                    if (!widevineManager) return i18n("Unknown");
-                    if (widevineManager.isInstalling) return i18n("Installing...");
-                    if (widevineManager.isInstalled) return i18n("Installed (version %1)", widevineManager.installedVersion);
-                    return i18n("Not installed");
-                }
-                color: widevineManager && widevineManager.isInstalled ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.neutralTextColor
+            text: {
+                if (!widevineManager) return i18n("Status: Unknown");
+                if (widevineManager.isInstalling) return i18n("Status: Installing...");
+                if (widevineManager.isInstalled) return i18n("Status: Installed (version %1)", widevineManager.installedVersion);
+                return i18n("Status: Not installed");
             }
         }
 
-        Kirigami.Separator {
-            Kirigami.FormData.label: i18nc("@title:group", "Actions:")
-            Kirigami.FormData.isSection: true
-        }
-
         RowLayout {
-            Kirigami.FormData.label: i18nc("@label", "Widevine CDM:")
+            Layout.fillWidth: true
             spacing: Kirigami.Units.smallSpacing
 
             QQC2.Button {
-                text: widevineManager && widevineManager.isInstalled ? i18n("Reinstall") : i18n("Install")
+                Layout.fillWidth: true
+                text: widevineManager && widevineManager.isInstalled ? i18n("Reinstall Widevine") : i18n("Install Widevine")
                 icon.name: "download"
                 enabled: widevineManager && !widevineManager.isInstalling
                 onClicked: {
@@ -68,6 +58,7 @@ Kirigami.ScrollablePage {
             }
 
             QQC2.Button {
+                Layout.fillWidth: true
                 text: i18n("Uninstall")
                 icon.name: "edit-delete"
                 visible: widevineManager && widevineManager.isInstalled
@@ -81,7 +72,6 @@ Kirigami.ScrollablePage {
         }
 
         QQC2.Label {
-            Kirigami.FormData.label: ""
             Layout.fillWidth: true
             wrapMode: QQC2.Label.WordWrap
             font: Kirigami.Theme.smallFont
@@ -89,16 +79,8 @@ Kirigami.ScrollablePage {
             text: i18n("After installing or uninstalling, restart Unify for changes to take effect.")
         }
 
-        Kirigami.Separator {
-            Kirigami.FormData.label: i18nc("@title:group", "Info:")
-            Kirigami.FormData.isSection: true
-        }
-
-        QQC2.Label {
-            Kirigami.FormData.label: ""
-            Layout.fillWidth: true
-            wrapMode: QQC2.Label.WordWrap
-            text: i18n("Some streaming services (Spotify, Netflix, Prime Video, etc.) require Widevine CDM to play DRM-protected content. Widevine is a Google proprietary library that cannot be bundled with the app.")
+        Item {
+            Layout.fillHeight: true
         }
     }
 

--- a/src/qml/settings/SettingsWidevine.qml
+++ b/src/qml/settings/SettingsWidevine.qml
@@ -1,0 +1,138 @@
+import QtQuick
+import QtQuick.Controls as QQC2
+import QtQuick.Layouts
+
+import org.kde.kirigami as Kirigami
+
+Kirigami.ScrollablePage {
+    id: root
+
+    title: i18nc("@title", "Widevine (DRM)")
+
+    Kirigami.ColumnView.fillWidth: true
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: Kirigami.Units.largeSpacing
+        spacing: Kirigami.Units.largeSpacing
+
+        Kirigami.Heading {
+            level: 3
+            text: i18n("DRM Content (Widevine)")
+            Layout.fillWidth: true
+        }
+
+        QQC2.Label {
+            Layout.fillWidth: true
+            wrapMode: QQC2.Label.WordWrap
+            text: i18n("Some streaming services (Spotify, Netflix, Prime Video, etc.) require Widevine CDM to play DRM-protected content.")
+        }
+
+        QQC2.Label {
+            Layout.fillWidth: true
+            wrapMode: QQC2.Label.WordWrap
+            text: i18n("Widevine is a Google proprietary library that cannot be bundled with the app.")
+        }
+
+        Kirigami.Separator {
+            Layout.fillWidth: true
+        }
+
+        Kirigami.FormLayout {
+            Layout.fillWidth: true
+
+            Kirigami.Separator {
+                Kirigami.FormData.label: i18nc("@title:group", "Installation Status:")
+                Kirigami.FormData.isSection: true
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            Kirigami.Icon {
+                source: widevineManager && widevineManager.isInstalled ? "dialog-ok-apply" : "dialog-warning"
+                color: widevineManager && widevineManager.isInstalled ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.neutralTextColor
+                Layout.preferredWidth: Kirigami.Units.iconSizes.small
+                Layout.preferredHeight: Kirigami.Units.iconSizes.small
+            }
+
+            QQC2.Label {
+                Layout.fillWidth: true
+                text: {
+                    if (!widevineManager) {
+                        return i18n("Status: Unknown");
+                    }
+                    if (widevineManager.isInstalling) {
+                        return i18n("Status: Installing...");
+                    }
+                    if (widevineManager.isInstalled) {
+                        return i18n("Status: Installed (version %1)", widevineManager.installedVersion);
+                    }
+                    return i18n("Status: Not installed");
+                }
+                color: widevineManager && widevineManager.isInstalled ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.neutralTextColor
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            QQC2.Button {
+                text: widevineManager && widevineManager.isInstalled ? i18n("Reinstall Widevine") : i18n("Install Widevine")
+                icon.name: "download"
+                enabled: widevineManager && !widevineManager.isInstalling
+                onClicked: {
+                    if (widevineManager) {
+                        widevineManager.install();
+                    }
+                }
+
+                QQC2.BusyIndicator {
+                    anchors.centerIn: parent
+                    running: widevineManager && widevineManager.isInstalling
+                    visible: running
+                }
+            }
+
+            QQC2.Button {
+                text: i18n("Uninstall")
+                icon.name: "edit-delete"
+                visible: widevineManager && widevineManager.isInstalled
+                enabled: widevineManager && !widevineManager.isInstalling
+                onClicked: {
+                    if (widevineManager) {
+                        widevineManager.uninstall();
+                    }
+                }
+            }
+        }
+
+        QQC2.Label {
+            Layout.fillWidth: true
+            wrapMode: QQC2.Label.WordWrap
+            font: Kirigami.Theme.smallFont
+            color: Kirigami.Theme.disabledTextColor
+            text: i18n("Note: After installing or uninstalling Widevine, you need to restart Unify for changes to take effect.")
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+    }
+
+    Connections {
+        target: widevineManager
+        function onInstallationStarted() {
+            applicationWindow().showPassiveNotification(i18n("Widevine installation started. This may take a moment..."), "long");
+        }
+        function onInstallationFinished(success, message) {
+            applicationWindow().showPassiveNotification(message, "long");
+        }
+        function onUninstallationFinished(success, message) {
+            applicationWindow().showPassiveNotification(message, "long");
+        }
+    }
+}

--- a/src/qml/settings/SettingsWidevine.qml
+++ b/src/qml/settings/SettingsWidevine.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 
 import org.kde.kirigami as Kirigami
 
-Kirigami.ScrollablePage {
+Kirigami.Page {
     id: root
 
     title: i18nc("@title", "Widevine (DRM)")
@@ -24,6 +24,7 @@ Kirigami.ScrollablePage {
 
         Kirigami.InlineMessage {
             Layout.fillWidth: true
+            visible: true
             type: widevineManager && widevineManager.isInstalled ? Kirigami.MessageType.Positive : Kirigami.MessageType.Information
             icon.name: widevineManager && widevineManager.isInstalled ? "dialog-ok-apply" : "dialog-warning"
 

--- a/src/qml/settings/SettingsWidevine.qml
+++ b/src/qml/settings/SettingsWidevine.qml
@@ -11,44 +11,16 @@ Kirigami.ScrollablePage {
 
     Kirigami.ColumnView.fillWidth: true
 
-    ColumnLayout {
+    Kirigami.FormLayout {
         anchors.fill: parent
-        anchors.margins: Kirigami.Units.largeSpacing
-        spacing: Kirigami.Units.largeSpacing
-
-        Kirigami.Heading {
-            level: 3
-            text: i18n("DRM Content (Widevine)")
-            Layout.fillWidth: true
-        }
-
-        QQC2.Label {
-            Layout.fillWidth: true
-            wrapMode: QQC2.Label.WordWrap
-            text: i18n("Some streaming services (Spotify, Netflix, Prime Video, etc.) require Widevine CDM to play DRM-protected content.")
-        }
-
-        QQC2.Label {
-            Layout.fillWidth: true
-            wrapMode: QQC2.Label.WordWrap
-            text: i18n("Widevine is a Google proprietary library that cannot be bundled with the app.")
-        }
 
         Kirigami.Separator {
-            Layout.fillWidth: true
-        }
-
-        Kirigami.FormLayout {
-            Layout.fillWidth: true
-
-            Kirigami.Separator {
-                Kirigami.FormData.label: i18nc("@title:group", "Installation Status:")
-                Kirigami.FormData.isSection: true
-            }
+            Kirigami.FormData.label: i18nc("@title:group", "Status:")
+            Kirigami.FormData.isSection: true
         }
 
         RowLayout {
-            Layout.fillWidth: true
+            Kirigami.FormData.label: i18nc("@label", "Installation:")
             spacing: Kirigami.Units.smallSpacing
 
             Kirigami.Icon {
@@ -59,29 +31,27 @@ Kirigami.ScrollablePage {
             }
 
             QQC2.Label {
-                Layout.fillWidth: true
                 text: {
-                    if (!widevineManager) {
-                        return i18n("Status: Unknown");
-                    }
-                    if (widevineManager.isInstalling) {
-                        return i18n("Status: Installing...");
-                    }
-                    if (widevineManager.isInstalled) {
-                        return i18n("Status: Installed (version %1)", widevineManager.installedVersion);
-                    }
-                    return i18n("Status: Not installed");
+                    if (!widevineManager) return i18n("Unknown");
+                    if (widevineManager.isInstalling) return i18n("Installing...");
+                    if (widevineManager.isInstalled) return i18n("Installed (version %1)", widevineManager.installedVersion);
+                    return i18n("Not installed");
                 }
                 color: widevineManager && widevineManager.isInstalled ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.neutralTextColor
             }
         }
 
+        Kirigami.Separator {
+            Kirigami.FormData.label: i18nc("@title:group", "Actions:")
+            Kirigami.FormData.isSection: true
+        }
+
         RowLayout {
-            Layout.fillWidth: true
+            Kirigami.FormData.label: i18nc("@label", "Widevine CDM:")
             spacing: Kirigami.Units.smallSpacing
 
             QQC2.Button {
-                text: widevineManager && widevineManager.isInstalled ? i18n("Reinstall Widevine") : i18n("Install Widevine")
+                text: widevineManager && widevineManager.isInstalled ? i18n("Reinstall") : i18n("Install")
                 icon.name: "download"
                 enabled: widevineManager && !widevineManager.isInstalling
                 onClicked: {
@@ -111,15 +81,24 @@ Kirigami.ScrollablePage {
         }
 
         QQC2.Label {
+            Kirigami.FormData.label: ""
             Layout.fillWidth: true
             wrapMode: QQC2.Label.WordWrap
             font: Kirigami.Theme.smallFont
             color: Kirigami.Theme.disabledTextColor
-            text: i18n("Note: After installing or uninstalling Widevine, you need to restart Unify for changes to take effect.")
+            text: i18n("After installing or uninstalling, restart Unify for changes to take effect.")
         }
 
-        Item {
-            Layout.fillHeight: true
+        Kirigami.Separator {
+            Kirigami.FormData.label: i18nc("@title:group", "Info:")
+            Kirigami.FormData.isSection: true
+        }
+
+        QQC2.Label {
+            Kirigami.FormData.label: ""
+            Layout.fillWidth: true
+            wrapMode: QQC2.Label.WordWrap
+            text: i18n("Some streaming services (Spotify, Netflix, Prime Video, etc.) require Widevine CDM to play DRM-protected content. Widevine is a Google proprietary library that cannot be bundled with the app.")
         }
     }
 


### PR DESCRIPTION
## Summary

Migrates all settings from the workspace drawer to a dedicated Settings window, following KDE HIG guidelines and matching the pattern used in ChatQT.

## Changes

### New Files
- `src/qml/settings/SettingsPage.qml` — Settings index with FormCard navigation
- `src/qml/settings/SettingsAppearance.qml` — Sidebar, header, and visual layout settings
- `src/qml/settings/SettingsBehavior.qml` — Audio, downloads, tray, and autostart settings
- `src/qml/settings/SettingsWidevine.qml` — Widevine DRM installation and management
- `src/qml/dialogs/TipsDialog.qml` — Extracted tips dialog (keyboard shortcuts, link handling, etc.)

### Modified Files
- `src/qml/drawers/WorkspaceDrawer.qml` — Removed all settings toggles; now contains only workspace navigation + Settings/Tips actions
- `src/qml/Main.qml` — Added SettingsPage component, TipsDialog instance, and `openSettings()` function
- `src/CMakeLists.txt` — Added new QML files to build
- `CMakeLists.txt` — Bumped version to 0.7.0
- `io.github.denysmb.unify.metainfo.xml` — Added release notes for v0.7.0

### Settings Organization

**Appearance:**
- Horizontal Sidebar toggle
- Sidebar Size (Tiny/Small/Normal/Big)
- Hide Header (Ctrl+H)
- Show Zoom Controls
- Show Workspaces Bar

**Behavior:**
- Mute All (global audio mute)
- Confirm Downloads
- System Tray (keep running in background)
- Autostart (launch on system start)

**Widevine (DRM):**
- Installation status indicator
- Install/Reinstall/Uninstall buttons
- Info about DRM content support